### PR TITLE
Implement resources for account, session and utility

### DIFF
--- a/lib/olm.ex
+++ b/lib/olm.ex
@@ -33,5 +33,7 @@ defmodule Olm do
 
   def init_utility(_utility_size), do: error("init_utility/1")
 
+  def create_account(_account_ref), do: error("create_account/1")
+
   defp error(function_name), do: :erlang.nif_error("NIF #{function_name} not implemented")
 end

--- a/lib/olm.ex
+++ b/lib/olm.ex
@@ -55,5 +55,7 @@ defmodule Olm do
   """
   def pickle_account_length(_account_ref), do: error("pickle_account_length/1")
 
+  def pickle_account(_account_ref, _key, _key_length), do: error("pickle_account/3")
+
   defp error(function_name), do: :erlang.nif_error("NIF #{function_name} not implemented")
 end

--- a/lib/olm.ex
+++ b/lib/olm.ex
@@ -50,5 +50,10 @@ defmodule Olm do
   """
   def account_last_error(_account_ref), do: error("account_last_error/1")
 
+  @doc """
+  Returns the number of bytes needed to store an account.
+  """
+  def pickle_account_length(_account_ref), do: error("pickle_account_length/1")
+
   defp error(function_name), do: :erlang.nif_error("NIF #{function_name} not implemented")
 end

--- a/lib/olm.ex
+++ b/lib/olm.ex
@@ -29,5 +29,9 @@ defmodule Olm do
 
   def init_account(_account_size), do: error("init_account/1")
 
+  def init_session(_session_size), do: error("init_session/1")
+
+  def init_utility(_utility_size), do: error("init_utility/1")
+
   defp error(function_name), do: :erlang.nif_error("NIF #{function_name} not implemented")
 end

--- a/lib/olm.ex
+++ b/lib/olm.ex
@@ -27,13 +27,28 @@ defmodule Olm do
   """
   def utility_size(), do: error("utility_size/0")
 
+  @doc """
+  Initialises an account object using the supplied memory.
+  The supplied memory must be at least `account_size/0` bytes.
+  """
   def init_account(_account_size), do: error("init_account/1")
 
+  @doc """
+  Initialises a session object using the supplied memory.
+  The supplied memory must be at least `session_size/0` bytes.
+  """
   def init_session(_session_size), do: error("init_session/1")
 
+  @doc """
+  Initialises a utility object using the supplied memory.
+  The supplied memory must be at least `utility_size/0` bytes.
+  """
   def init_utility(_utility_size), do: error("init_utility/1")
 
-  def create_account(_account_ref), do: error("create_account/1")
+  @doc """
+  A null terminated string describing the most recent error to happen to an account.
+  """
+  def account_last_error(_account_ref), do: error("account_last_error/1")
 
   defp error(function_name), do: :erlang.nif_error("NIF #{function_name} not implemented")
 end

--- a/lib/olm.ex
+++ b/lib/olm.ex
@@ -27,7 +27,7 @@ defmodule Olm do
   """
   def utility_size(), do: error("utility_size/0")
 
-  def init_account(), do: error("init_account/0")
+  def init_account(_account_size), do: error("init_account/1")
 
   defp error(function_name), do: :erlang.nif_error("NIF #{function_name} not implemented")
 end

--- a/lib/olm.ex
+++ b/lib/olm.ex
@@ -27,5 +27,7 @@ defmodule Olm do
   """
   def utility_size(), do: error("utility_size/0")
 
+  def init_account(), do: error("init_account/0")
+
   defp error(function_name), do: :erlang.nif_error("NIF #{function_name} not implemented")
 end

--- a/native/src/olm_nifs.c
+++ b/native/src/olm_nifs.c
@@ -44,15 +44,35 @@ utility_size(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 static ERL_NIF_TERM
 init_account(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
-    size_t size = argv[0];
+    size_t account_size = argv[0];
 
     // BEAM specific impl of malloc, won't be GC and needs to be freed.
-    OlmAccount* memory  = enif_alloc(size);
+    OlmAccount* memory  = enif_alloc(account_size);
     OlmAccount* account = olm_account(memory);
 
-    ERL_NIF_TERM term = enif_make_resource(env, &account);
+    return enif_make_resource(env, &account);
+}
 
-    return term;
+static ERL_NIF_TERM
+init_session(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    size_t session_size = argv[0];
+
+    OlmSession* memory  = enif_alloc(session_size);
+    OlmSession* session = olm_session(memory);
+
+    return enif_make_resource(env, &session);
+}
+
+static ERL_NIF_TERM
+init_utility(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    size_t utility_size = argv[0];
+
+    OlmUtility* memory  = enif_alloc(utility_size);
+    OlmUtility* utility = olm_utility(memory);
+
+    return enif_make_resource(env, &utility);
 }
 
 // Let's define the array of ErlNifFunc beforehand:
@@ -62,6 +82,8 @@ static ErlNifFunc nif_funcs[] = {
     {"account_size", 0, account_size},
     {"session_size", 0, session_size},
     {"utility_size", 0, utility_size},
-    {"init_account", 1, init_account}};
+    {"init_account", 1, init_account},
+    {"init_session", 1, init_session},
+    {"init_utility", 1, init_utility}};
 
 ERL_NIF_INIT(Elixir.Olm, nif_funcs, NULL, NULL, NULL, NULL)

--- a/native/src/olm_nifs.c
+++ b/native/src/olm_nifs.c
@@ -44,9 +44,9 @@ utility_size(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 static ERL_NIF_TERM
 init_account(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
-    size_t size = olm_account_size();
+    size_t size = argv[0];
 
-    // Also works with malloc
+    // BEAM specific impl of malloc, won't be GC and needs to be freed.
     OlmAccount* memory  = enif_alloc(size);
     OlmAccount* account = olm_account(memory);
 
@@ -62,6 +62,6 @@ static ErlNifFunc nif_funcs[] = {
     {"account_size", 0, account_size},
     {"session_size", 0, session_size},
     {"utility_size", 0, utility_size},
-    {"init_account", 0, init_account}};
+    {"init_account", 1, init_account}};
 
 ERL_NIF_INIT(Elixir.Olm, nif_funcs, NULL, NULL, NULL, NULL)

--- a/native/src/olm_nifs.c
+++ b/native/src/olm_nifs.c
@@ -41,12 +41,27 @@ utility_size(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return enif_make_ulong(env, size);
 }
 
+static ERL_NIF_TERM
+init_account(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    size_t size = olm_account_size();
+
+    // Also works with malloc
+    OlmAccount* memory  = enif_alloc(size);
+    OlmAccount* account = olm_account(memory);
+
+    ERL_NIF_TERM term = enif_make_resource(env, &account);
+
+    return term;
+}
+
 // Let's define the array of ErlNifFunc beforehand:
 static ErlNifFunc nif_funcs[] = {
     // {erl_function_name, erl_function_arity, c_function}
     {"version", 0, version},
     {"account_size", 0, account_size},
     {"session_size", 0, session_size},
-    {"utility_size", 0, utility_size}};
+    {"utility_size", 0, utility_size},
+    {"init_account", 0, init_account}};
 
 ERL_NIF_INIT(Elixir.Olm, nif_funcs, NULL, NULL, NULL, NULL)

--- a/native/src/olm_nifs.c
+++ b/native/src/olm_nifs.c
@@ -87,10 +87,10 @@ init_account(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     OlmAccount* memory  = enif_alloc_resource(account_resource, account_size);
     OlmAccount* account = olm_account(memory);
-    
-    ERL_NIF_TERM term = enif_make_resource(env, &account);
+
+    ERL_NIF_TERM term = enif_make_resource(env, account);
     enif_release_resource(account);
-    
+
     return term;
 }
 
@@ -102,7 +102,7 @@ init_session(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     OlmSession* memory  = enif_alloc_resource(session_resource, session_size);
     OlmSession* session = olm_session(memory);
 
-    return enif_make_resource(env, &session);
+    return enif_make_resource(env, session);
 }
 
 static ERL_NIF_TERM
@@ -113,7 +113,7 @@ init_utility(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     OlmUtility* memory  = enif_alloc_resource(utility_resource, utility_size);
     OlmUtility* utility = olm_utility(memory);
 
-    return enif_make_resource(env, &utility);
+    return enif_make_resource(env, utility);
 }
 
 static ERL_NIF_TERM
@@ -127,6 +127,17 @@ account_last_error(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return enif_make_string(env, last_error, ERL_NIF_LATIN1);
 }
 
+static ERL_NIF_TERM
+pickle_account_length(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    OlmAccount* account;
+    enif_get_resource(env, argv[0], account_resource, (void**) &account);
+
+    size_t length = olm_pickle_account_length(account);
+
+    return enif_make_ulong(env, length);
+}
+
 // Let's define the array of ErlNifFunc beforehand:
 static ErlNifFunc nif_funcs[] = {
     // {erl_function_name, erl_function_arity, c_function}
@@ -137,6 +148,7 @@ static ErlNifFunc nif_funcs[] = {
     {"init_account", 1, init_account},
     {"init_session", 1, init_session},
     {"init_utility", 1, init_utility},
-    {"account_last_error", 1, account_last_error}};
+    {"account_last_error", 1, account_last_error},
+    {"pickle_account_length", 1, pickle_account_length}};
 
 ERL_NIF_INIT(Elixir.Olm, nif_funcs, nif_load, NULL, NULL, NULL)

--- a/native/src/olm_nifs.c
+++ b/native/src/olm_nifs.c
@@ -138,6 +138,29 @@ pickle_account_length(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return enif_make_ulong(env, length);
 }
 
+static ERL_NIF_TERM
+pickle_account(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    OlmAccount* account;
+    enif_get_resource(env, argv[0], account_resource, (void**) &account);
+
+    size_t key_length;
+    enif_get_ulong(env, argv[2], &key_length);
+
+    char key[key_length];
+    enif_get_string(env, argv[1], key, key_length, ERL_NIF_LATIN1);
+
+    // Move this to args?
+    size_t pickled_length = olm_pickle_account_length(account);
+
+    char pickled[pickled_length];
+    // We probably need some error handling here.
+    size_t res =
+        olm_pickle_account(account, key, key_length, pickled, pickled_length);
+
+    return enif_make_string(env, pickled, ERL_NIF_LATIN1);
+}
+
 // Let's define the array of ErlNifFunc beforehand:
 static ErlNifFunc nif_funcs[] = {
     // {erl_function_name, erl_function_arity, c_function}
@@ -149,6 +172,7 @@ static ErlNifFunc nif_funcs[] = {
     {"init_session", 1, init_session},
     {"init_utility", 1, init_utility},
     {"account_last_error", 1, account_last_error},
-    {"pickle_account_length", 1, pickle_account_length}};
+    {"pickle_account_length", 1, pickle_account_length},
+    {"pickle_account", 3, pickle_account}};
 
 ERL_NIF_INIT(Elixir.Olm, nif_funcs, nif_load, NULL, NULL, NULL)

--- a/test/olm_test.exs
+++ b/test/olm_test.exs
@@ -23,14 +23,30 @@ defmodule OlmTest do
   end
 
   test "initiliase an account" do
-    assert is_reference(Olm.init_account(Olm.account_size()))
+    assert Olm.account_size()
+           |> Olm.init_account()
+           |> is_reference()
   end
 
   test "initiliase a session" do
-    assert is_reference(Olm.init_session(Olm.session_size()))
+    assert Olm.session_size()
+           |> Olm.init_session()
+           |> is_reference()
   end
 
   test "initiliase a utility" do
-    assert is_reference(Olm.init_utility(Olm.utility_size()))
+    assert Olm.utility_size()
+           |> Olm.init_utility()
+           |> is_reference()
+  end
+
+  test "returns the most recent error to happen to an account" do
+    charlist =
+      Olm.account_size()
+      |> Olm.init_account()
+      |> Olm.account_last_error()
+
+    assert is_list(charlist)
+    assert 'SUCCESS' == charlist
   end
 end

--- a/test/olm_test.exs
+++ b/test/olm_test.exs
@@ -51,13 +51,23 @@ defmodule OlmTest do
   end
 
   test "returns number of bytest needed to store an account" do
-    pickle_length =
+    pickled_length =
       Olm.account_size()
       |> Olm.init_account()
       |> Olm.pickle_account_length()
 
-    assert is_integer(pickle_length)
+    assert is_integer(pickled_length)
     # Don't know if this value is consistent...
-    assert pickle_length == 246
+    assert pickled_length == 246
+  end
+
+  test "returns an account stored as an encrypted base64 string" do
+    pickled_account =
+      Olm.account_size()
+      |> Olm.init_account()
+      |> Olm.pickle_account('key', 4)
+
+    assert is_list(pickled_account)
+    assert length(pickled_account) == 246
   end
 end

--- a/test/olm_test.exs
+++ b/test/olm_test.exs
@@ -25,4 +25,12 @@ defmodule OlmTest do
   test "initiliase an account" do
     assert is_reference(Olm.init_account(Olm.account_size()))
   end
+
+  test "initiliase a session" do
+    assert is_reference(Olm.init_session(Olm.session_size()))
+  end
+
+  test "initiliase a utility" do
+    assert is_reference(Olm.init_utility(Olm.utility_size()))
+  end
 end

--- a/test/olm_test.exs
+++ b/test/olm_test.exs
@@ -21,4 +21,8 @@ defmodule OlmTest do
   test "get utiliy size" do
     assert is_integer(Olm.utility_size())
   end
+
+  test "initiliase an account" do
+    assert is_reference(Olm.init_account(Olm.account_size()))
+  end
 end

--- a/test/olm_test.exs
+++ b/test/olm_test.exs
@@ -49,4 +49,15 @@ defmodule OlmTest do
     assert is_list(charlist)
     assert 'SUCCESS' == charlist
   end
+
+  test "returns number of bytest needed to store an account" do
+    pickle_length =
+      Olm.account_size()
+      |> Olm.init_account()
+      |> Olm.pickle_account_length()
+
+    assert is_integer(pickle_length)
+    # Don't know if this value is consistent...
+    assert pickle_length == 246
+  end
 end


### PR DESCRIPTION
I've started dipping my toes into this again. I'm not sure if this is the right solution as it doesn't use `enif_alloc_resource`. This seems to return a reference to the location in memory for the account. I'm guessing this means it won't be automatically garbage collected as we will need to call `enif_release_resource` manually. 

Edit: can confirm this is the case: `enif_alloc` (BEAM specific implementation of `malloc`) is probably a good call as we'll want to manually release the memory.

Edit2: I'm not sure using `enif_alloc` with `enif_make_resource` is safe...

Edit3: Now sure we need `enif_alloc_resource`.

I'm starting with a thin wrapper, we can add another layer which abstracts memory management in future. 

Edit4: Got resources to work (I think), not sure what the API should look like in this case. 
Re-memory-abstraction: perhaps things like `account_size` should be abstracted in `init_account` for example? 

@fancycade I'm punching above my weight on this, some guidance would be highly appreciated. 