### PR TITLE
Refactor code compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Olm
 
-Elixir wrapper for [Olm](https://gitlab.matrix.org/matrix-org/olm).
+Elixir wrapper for [Olm](https://gitlab.matrix.org/matrix-org/olm), an
+implementation of the Double Ratchet cryptographic ratchet.
 
 ## Installation
 
@@ -10,13 +11,12 @@ On Debian one can install it like so:
 
     apt install libolm-dev
 
-On Darwin: 
+On Darwin:
 
     brew install libolm
 
-NOTE: one must set the `ERL_ROOT` environment var, usually `/usr/local/lib/erlang/erts-version`
-
-Once this is done, the package can be installed by adding `olm` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `olm` to your list of dependencies in
+`mix.exs`:
 
 ```elixir
 def deps do

--- a/mix.exs
+++ b/mix.exs
@@ -65,4 +65,10 @@ defmodule Mix.Tasks.Compile.OlmNifs do
     {result, _errcode} = System.cmd("make", [], stderr_to_stdout: true)
     IO.binwrite(result)
   end
+
+  def clean do
+    if File.exists?("priv/olm_nif.so") do
+      File.rm!("priv/olm_nif.so")
+    end
+  end
 end


### PR DESCRIPTION
This PR refactors the C source code compilation of using dynamic instead of hard code path.

Code compilation
```
$ mix compile                                             
cc -fPIC -shared -I/home/foobar/.asdf/installs/erlang/21.1.4/erts-10.1.3/include -o priv/olm_nif.so c_src/olm_nif.c -lol
m                                                                                                                    
Compiling 5 files (.ex)                                                                                              
Generated olm app
...
```

Recompilation.
```
$ mix compile
make: Nothing to be done for 'all'.
```

Compilation clean up.
```
$ mix clean
```